### PR TITLE
Upgrade maven-settings-action to latest version

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -40,7 +40,7 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
 
-      - uses: s4u/maven-settings-action@v2.2.0
+      - uses: s4u/maven-settings-action@v2.8.0
         with:
           servers: |
             [{

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -52,7 +52,7 @@ jobs:
           key: ${{ secrets.SSH_PRIVATE_KEY_PEM }}
           known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
 
-      - uses: s4u/maven-settings-action@v2.2.0
+      - uses: s4u/maven-settings-action@v2.8.0
         with:
           servers: |
             [{


### PR DESCRIPTION
Motivation:

We should use the latest maven-settings-action to fix warnings

Modifications:

Update maven-settings-action to 2.8.0

Result:

No more warnings