### PR TITLE
Migrate to using maven central

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -44,9 +44,9 @@ jobs:
         with:
           servers: |
             [{
-                "id": "sonatype-nexus-snapshots",
-                "username": "${{ secrets.SONATYPE_USERNAME }}",
-                "password": "${{ secrets.SONATYPE_PASSWORD }}"
+                "id": "central",
+                "username": "${{ secrets.MAVEN_CENTRAL_USERNAME }}",
+                "password": "${{ secrets.MAVEN_CENTRAL_PASSWORD }}"
             }]
 
       - run: mvn -B -ntp --file pom.xml clean deploy

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -56,16 +56,16 @@ jobs:
         with:
           servers: |
             [{
-                "id": "sonatype-nexus",
-                "username": "${{ secrets.SONATYPE_USERNAME }}",
-                "password": "${{ secrets.SONATYPE_PASSWORD }}"
+                "id": "central",
+                "username": "${{ secrets.MAVEN_CENTRAL_USERNAME }}",
+                "password": "${{ secrets.MAVEN_CENTRAL_PASSWORD }}"
             }]
 
       - name: Prepare release with Maven
         run: mvn -B --file pom.xml release:prepare -DpreparationGoals=clean
 
       - name: Perform release with Maven
-        run: mvn -B --file pom.xml release:perform -Drelease.gpg.keyname=${{ secrets.GPG_KEYNAME }} -Drelease.gpg.passphrase=${{ secrets.GPG_PASSPHRASE }} -DstagingProgressTimeoutMinutes=10
+        run: mvn -B --file pom.xml release:perform -Drelease.gpg.keyname=${{ secrets.GPG_KEYNAME }} -Drelease.gpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
 
       - name: Rollback release on failure
         if: ${{ failure() }}

--- a/pom.xml
+++ b/pom.xml
@@ -80,17 +80,14 @@
           <goal>resolve</goal>
         </goals>
       </plugin>
-
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
         <extensions>true</extensions>
         <configuration>
-          <serverId>sonatype-nexus</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <!-- Automatically release the artifacts after the verification was complete -->
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          <publishingServerId>central</publishingServerId>
+          <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Motivation:

OSSRH is deprecated and will be shut down soon. Let's switch to using maven central

Modifications:

- Replace old plugin with central-publishing-maven-plugin
- Adjust workflow to setup the right token / password

Result:

Snapshot deployments and release works again